### PR TITLE
画像ファイルのディレクトリ指定

### DIFF
--- a/main .tex
+++ b/main .tex
@@ -1,6 +1,7 @@
 \documentclass[12pt,a4j,titlepage]{ltjsarticle}
 \usepackage{semi}
 \usepackage{here}
+\graphicspath{{./figures/}}  % 画像ファイルのディレクトリを指定
 
 % \title{}
 % \author{}


### PR DESCRIPTION
画像ファイルのディレクトリとしてfiguresを指定してください．
もしかしてCloudLaTeXでは，この指定がなくてもコンパイルできるのでしょうか？